### PR TITLE
Safer perplexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Creates and returns a TSNE optimizer.
 
 - `data` must be a Rank 2 tensor. Shape is [numPoints, dataPointDimensions]
 - `config` is an optinal object with the following params (all are optional):
-  - perplexity: number — defaults to 30. Max value is 42
+  - perplexity: number — defaults to 18. Max value is defined by hardware limitations.
   - verbose: boolean — defaults to false
   - exaggeration: number — defaults to 4
   - exaggerationIter: number — defaults to 300

--- a/examples/script_tag/index.html
+++ b/examples/script_tag/index.html
@@ -9,7 +9,7 @@
 
 <body>
   <h1>tfjs-tsne simple example</h1>
-  <p>Reduce 20000 points with 100 dimensions each. Open up the browser console to see progress while the embedding is being
+  <p>Reduce 10000 points with 100 dimensions each. Open up the browser console to see progress while the embedding is being
     computed.
   </p>
   <script src="./index.js" defer></script>

--- a/examples/script_tag/index.js
+++ b/examples/script_tag/index.js
@@ -54,7 +54,7 @@ function generateData(numDimensions, numPoints) {
  */
 async function computeEmbedding(data, numPoints) {
   const embedder = tsne.tsne(data, {
-    perplexity: 30,
+    perplexity: 18,
     verbose: true,
     knnMode: 'auto',
   });

--- a/examples/synthetic_data/index.html
+++ b/examples/synthetic_data/index.html
@@ -3,7 +3,7 @@
 <body>
   <h1>tfjs-tsne simple example</h1>
   <p>
-    Reduce 20000 points with 100 dimensions each. Open up the browser console to see progress while the embedding is being computed.
+    Reduce 10000 points with 100 dimensions each. Open up the browser console to see progress while the embedding is being computed.
   </p>
   <script src="./index.js"></script>
 </body>

--- a/examples/synthetic_data/index.js
+++ b/examples/synthetic_data/index.js
@@ -56,7 +56,7 @@ function generateData(numDimensions, numPoints) {
  */
 async function computeEmbedding(data, numPoints) {
   const embedder = tsne.tsne(data, {
-    perplexity: 30,
+    perplexity: 18,
     verbose: true,
     knnMode: 'auto',
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@
  */
 
 import {KNNEstimator} from './knn';
-import {tsne} from './tsne';
+import {maximumPerplexity, tsne} from './tsne';
 import {TSNEOptimizer} from './tsne_optimizer';
 
-export {KNNEstimator, tsne, TSNEOptimizer};
+export {KNNEstimator, maximumPerplexity, tsne, TSNEOptimizer};

--- a/src/tsne.ts
+++ b/src/tsne.ts
@@ -23,7 +23,7 @@ import {tensorToDataTexture} from './tensor_to_data_texture';
 import {TSNEOptimizer} from './tsne_optimizer';
 
 export interface TSNEConfiguration {
-  perplexity?: number;             // Default: 30
+  perplexity?: number;             // Default: 18
   exaggeration?: number;           // Default: 4
   exaggerationIter?: number;       // Default: 300
   exaggerationDecayIter?: number;  // Default: 200
@@ -79,7 +79,7 @@ export class TSNE {
    */
   private async initialize(): Promise<void> {
     // Default parameters
-    let perplexity = 30;
+    let perplexity = 18;
     let exaggeration = 4;
     let exaggerationIter = 300;
     let exaggerationDecayIter = 200;

--- a/src/tsne.ts
+++ b/src/tsne.ts
@@ -23,14 +23,32 @@ import {tensorToDataTexture} from './tensor_to_data_texture';
 import {TSNEOptimizer} from './tsne_optimizer';
 
 export interface TSNEConfiguration {
-  perplexity?: number;             // Default: 18
-  exaggeration?: number;           // Default: 4
-  exaggerationIter?: number;       // Default: 300
-  exaggerationDecayIter?: number;  // Default: 200
-  momentum?: number;               // Default: 0.8
-  verbose?: boolean;               // Default: false
+  perplexity?: number;            // Default: 18
+  exaggeration?: number;          // Default: 4
+  exaggerationIter?: number;      // Default: 300
+  exaggerationDecayIter?: number; // Default: 200
+  momentum?: number;              // Default: 0.8
+  verbose?: boolean;              // Default: false
   knnMode: 'auto'|'bruteForce';
   // Default: auto
+}
+
+/**
+ * Returns the maximum value of perplexity given the available
+ * WebGL capabilities.
+ */
+export function maximumPerplexity() {
+  const backend = tf.ENV.findBackend('webgl') as tf.webgl.MathBackendWebGL;
+  if (backend === null) {
+    throw Error('WebGL backend is not available');
+  }
+  const gl = backend.getGPGPUContext().gl;
+  const maxVaryingVectors = gl.getParameter(gl.MAX_VARYING_VECTORS);
+  // one vector is reserved and each vector contains 4 neighbors;
+  const numNeighbors = (maxVaryingVectors - 1) * 4;
+  // the maximum perplexity is a third of the maximum number of neighbors
+  const maximumPerplexity = Math.floor(numNeighbors / 3);
+  return maximumPerplexity;
 }
 
 /**
@@ -69,6 +87,19 @@ export class TSNE {
 
     if (inputShape.length !== 2) {
       throw Error('computeTSNE: input tensor must be 2-dimensional');
+    }
+
+    // Checking for a valid perplexity value given hardware limitations
+    let perplexity = 18;
+    if (this.config !== undefined) {
+      if (this.config.perplexity !== undefined) {
+        perplexity = this.config.perplexity;
+      }
+    }
+    const maxPerplexity = maximumPerplexity();
+    if (perplexity > maxPerplexity) {
+      throw Error(`computeTSNE: perplexity cannot be greater than` +
+                  `${maxPerplexity} on this machine`);
     }
   }
 
@@ -112,10 +143,6 @@ export class TSNE {
       }
     }
 
-    // Number of neighbors cannot exceed 128
-    if (perplexity > 42) {
-      throw Error('computeTSNE: perplexity cannot be greater than 42');
-    }
     // Neighbors must be roughly 3*perplexity and a multiple of 4
     this.numNeighbors = Math.floor((perplexity * 3) / 4) * 4;
     this.packedData = await tensorToDataTexture(this.data);

--- a/src/tsne_test.ts
+++ b/src/tsne_test.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import * as tf from '@tensorflow/tfjs-core';
+import * as tf_tsne from './tsne';
+
+/**
+ * Returns a simple dataset for testing
+ */
+function generateData() {
+  const numPoints = 300;
+  const numDimensions = 10;
+  const data = tf.tidy(() => {
+    return tf.linspace(0, 1, numPoints * numDimensions)
+        .reshape([ numPoints, numDimensions ])
+        .add(tf.randomUniform([ numPoints, numDimensions ]));
+  });
+  return data;
+}
+
+describe('TSNE class', () => {
+  it('throws an error if the perplexity is too high', () => {
+    const data = generateData();
+    expect(() => {
+      tf_tsne.tsne(data, {
+        perplexity : 100,
+        verbose : false,
+        knnMode : 'auto',
+      });
+    }).toThrow();
+
+    data.dispose();
+  });
+});
+
+describe('TSNE class', () => {
+  it('throws an error if the perplexity is too high on this system ', () => {
+    const data = generateData();
+    const maximumPerplexity = tf_tsne.maximumPerplexity();
+    expect(() => {
+      tf_tsne.tsne(data, {
+        perplexity : maximumPerplexity + 1,
+        verbose : false,
+        knnMode : 'auto',
+      });
+    }).toThrow();
+
+    data.dispose();
+  });
+});
+
+describe('TSNE class', () => {
+  it('does not throw an error if the perplexity is set to the maximum value',
+     () => {
+       const data = generateData();
+       const maximumPerplexity = tf_tsne.maximumPerplexity();
+       expect(() => {
+         tf_tsne.tsne(data, {
+           perplexity : maximumPerplexity,
+           verbose : false,
+           knnMode : 'auto',
+         });
+       }).not.toThrow();
+
+       data.dispose();
+     });
+});


### PR DESCRIPTION
The maximum perplexity is bounded by MAX_VARYING_VECTORS.
30 is too high for a Mac users and 18 is a safer value.

I think it is nice to have a way to ask for the maximum perplexity allowed by the system.
Where do you think is a good place to put the function? in the TSNE class? as a global function?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-tsne/50)
<!-- Reviewable:end -->
